### PR TITLE
⬆ v2.1.1 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "dependencies": {
     "@chrisellis/react-carpentry": "^0.4.1",

--- a/src/components/RichTextEditor/RichTextDisplay.tsx
+++ b/src/components/RichTextEditor/RichTextDisplay.tsx
@@ -62,7 +62,7 @@ const RichTextH3 = styled.h3`
   margin: 0;
 `;
 const RichTextP = styled.p``;
-const RichTextStrikeThrough = styled.del``;
+const RichTextStrikeThrough = styled.s``;
 const RichTextSubscript = styled.sub``;
 const RichTextSuperscript = styled.sup``;
 const RichTextImg = styled.img``;


### PR DESCRIPTION
- 🐛 Changed `<del>` to `<s>` as I believe it is more semantically appropriate for my use-cases, and it is tagged as `<s>` in my markup - it should match so that it behaves predictably.